### PR TITLE
Replace bitnami/kafka with soldevelo/kafka (free alternative)

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -1,3 +1,3 @@
-FROM bitnami/kafka:latest
+FROM soldevelo/kafka:latest
 
 LABEL maintainer="liuyuede123 <liufutianoppo@163.com>"


### PR DESCRIPTION
I suggest this change because the Bitnami Kafka image is now behind a paywall and no longer publicly available, which prevents CI/CD and local environments from functioning properly.

The Soldevelo Kafka image is a drop-in replacement that remains fully compatible with Bitnami's configuration and environment variables. It's actively maintained and provides the same functionality.